### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/bdf3-parent/bdf3-dbconsole/src/main/java/com/bstek/bdf3/dbconsole/service/impl/DbCommonServiceImpl.java
+++ b/bdf3-parent/bdf3-dbconsole/src/main/java/com/bstek/bdf3/dbconsole/service/impl/DbCommonServiceImpl.java
@@ -23,7 +23,7 @@ import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import com.bstek.bdf3.dbconsole.DbConstants;
@@ -39,7 +39,7 @@ import com.bstek.bdf3.dbconsole.service.IDbCommonService;
 import com.bstek.dorado.core.Configure;
 
 
-@Component(IDbCommonService.BEAN_ID)
+@Service
 public class DbCommonServiceImpl implements IDbCommonService {
 
 	@Autowired


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code. 

A Spring bean in the service layer should be annotated using @Service instead of @Component annotation.
@Service annotation is a specialization of @Component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @Service is a better choice.