### PR TITLE
一个更好的注解使用的建议

### DIFF
--- a/bdf3-parent/bdf3-dbconsole/src/main/java/com/bstek/bdf3/dbconsole/service/impl/DbCommonServiceImpl.java
+++ b/bdf3-parent/bdf3-dbconsole/src/main/java/com/bstek/bdf3/dbconsole/service/impl/DbCommonServiceImpl.java
@@ -23,7 +23,7 @@ import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import com.bstek.bdf3.dbconsole.DbConstants;
@@ -39,7 +39,7 @@ import com.bstek.bdf3.dbconsole.service.IDbCommonService;
 import com.bstek.dorado.core.Configure;
 
 
-@Component(IDbCommonService.BEAN_ID)
+@Service
 public class DbCommonServiceImpl implements IDbCommonService {
 
 	@Autowired


### PR DESCRIPTION
您好，我发现您的代码中的注释可能有一些小的改进。

服务层中的 Spring bean 应该使用 @service 而不是 @component 注解进行注解。
@service注解是@component在服务层的特化。 通过使用专门的注解，可以得到更优的效果。 首先，它们被视为 Spring bean，其次，您可以放置该层所需的特殊行为。

为了更好地理解和维护大型应用程序，@service 是更好的选择。